### PR TITLE
Update a typo at education section

### DIFF
--- a/index.html
+++ b/index.html
@@ -204,7 +204,7 @@
       </section>
       <section class="education" id="education">
         <div class="education-title-div">
-          <h2 class="education-title">Edecation</h2>
+          <h2 class="education-title">Education</h2>
         </div>
         <div class="education-item-div">
           <div class="education-item">


### PR DESCRIPTION
The previous version was "Edecation" at the Education section now corrected to "Education"